### PR TITLE
Replace Bucket4j dependency with custom rate limiter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,11 +65,6 @@
             <artifactId>postgresql</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.github.vladimir-bukhtoyarov</groupId>
-            <artifactId>bucket4j-core</artifactId>
-            <version>8.10.1</version>
-        </dependency>
-        <dependency>
             <groupId>org.springdoc</groupId>
             <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
             <version>2.5.0</version>


### PR DESCRIPTION
## Summary
- replace the Bucket4j-based rate limiting logic with a simple fixed-window counter implemented with core Java classes
- remove the Bucket4j dependency from the Maven build configuration

## Testing
- mvn -q -DskipTests package *(fails: unable to download dependencies from Maven Central; received HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_68dc340620e083279ef8a55fa0485c7a