### PR TITLE
Switch session updates to PATCH and tighten validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,8 +72,8 @@ All endpoints require a valid `X-API-KEY` header (except health checks). Swagger
 | --- | --- |
 | `POST /api/v1/sessions` | Create a session. Body: `{ "userId": "user-123", "title": "My chat" }` |
 | `GET /api/v1/sessions?userId={id}` | List sessions for a user. |
-| `PUT /api/v1/sessions/{sessionId}/rename?userId={id}` | Rename a session. Body: `{ "title": "New name" }` |
-| `PUT /api/v1/sessions/{sessionId}/favorite?userId={id}` | Toggle favorites. Body: `{ "favorite": true }` |
+| `PATCH /api/v1/sessions/{sessionId}/rename?userId={id}` | Rename a session. Body: `{ "title": "New name" }` |
+| `PATCH /api/v1/sessions/{sessionId}/favorite?userId={id}` | Toggle favorites. Body: `{ "favorite": true }` |
 | `DELETE /api/v1/sessions/{sessionId}?userId={id}` | Delete a session and its messages. |
 
 ### Message Management

--- a/src/main/java/com/example/chatstorage/controller/ChatSessionController.java
+++ b/src/main/java/com/example/chatstorage/controller/ChatSessionController.java
@@ -14,8 +14,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -48,14 +48,14 @@ public class ChatSessionController {
         return chatSessionService.listSessions(userId);
     }
 
-    @PutMapping("/sessions/{sessionId}/rename")
+    @PatchMapping("/sessions/{sessionId}/rename")
     public ChatSessionResponse renameSession(@PathVariable("sessionId") UUID sessionId,
                                              @RequestParam("userId") String userId,
                                              @Valid @RequestBody ChatSessionRenameRequest request) {
         return chatSessionService.renameSession(sessionId, userId, request.getTitle());
     }
 
-    @PutMapping("/sessions/{sessionId}/favorite")
+    @PatchMapping("/sessions/{sessionId}/favorite")
     public ChatSessionResponse updateFavorite(@PathVariable("sessionId") UUID sessionId,
                                               @RequestParam("userId") String userId,
                                               @Valid @RequestBody ChatSessionFavoriteRequest request) {

--- a/src/main/java/com/example/chatstorage/dto/ChatMessageCreateRequest.java
+++ b/src/main/java/com/example/chatstorage/dto/ChatMessageCreateRequest.java
@@ -3,6 +3,7 @@ package com.example.chatstorage.dto;
 import com.example.chatstorage.domain.SenderType;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 
 public class ChatMessageCreateRequest {
 
@@ -10,8 +11,10 @@ public class ChatMessageCreateRequest {
     private SenderType sender;
 
     @NotBlank
+    @Size(max = 5000)
     private String content;
 
+    @Size(max = 5000)
     private String context;
 
     public SenderType getSender() {

--- a/src/main/java/com/example/chatstorage/dto/ChatSessionRenameRequest.java
+++ b/src/main/java/com/example/chatstorage/dto/ChatSessionRenameRequest.java
@@ -1,10 +1,12 @@
 package com.example.chatstorage.dto;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 
 public class ChatSessionRenameRequest {
 
     @NotBlank
+    @Size(max = 20)
     private String title;
 
     public String getTitle() {

--- a/src/main/java/com/example/chatstorage/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/chatstorage/error/GlobalExceptionHandler.java
@@ -3,13 +3,17 @@ package com.example.chatstorage.error;
 import com.example.chatstorage.service.ResourceNotFoundException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import jakarta.validation.ConstraintViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.context.request.ServletWebRequest;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
 import java.time.OffsetDateTime;
 import java.util.stream.Collectors;
@@ -30,6 +34,31 @@ public class GlobalExceptionHandler {
                 .map(this::formatFieldError)
                 .collect(Collectors.joining(", "));
         return buildResponse(HttpStatus.BAD_REQUEST, "VALIDATION_ERROR", message, request);
+    }
+
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ResponseEntity<ApiError> handleConstraintViolation(ConstraintViolationException ex, ServletWebRequest request) {
+        String message = ex.getConstraintViolations().stream()
+                .map(violation -> violation.getPropertyPath() + " " + violation.getMessage())
+                .collect(Collectors.joining(", "));
+        return buildResponse(HttpStatus.BAD_REQUEST, "CONSTRAINT_VIOLATION", message, request);
+    }
+
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<ApiError> handleMessageNotReadable(HttpMessageNotReadableException ex, ServletWebRequest request) {
+        return buildResponse(HttpStatus.BAD_REQUEST, "INVALID_REQUEST_BODY", "Request body is malformed or missing", request);
+    }
+
+    @ExceptionHandler(MissingServletRequestParameterException.class)
+    public ResponseEntity<ApiError> handleMissingParameter(MissingServletRequestParameterException ex, ServletWebRequest request) {
+        String message = "Missing required parameter '%s'".formatted(ex.getParameterName());
+        return buildResponse(HttpStatus.BAD_REQUEST, "MISSING_PARAMETER", message, request);
+    }
+
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    public ResponseEntity<ApiError> handleTypeMismatch(MethodArgumentTypeMismatchException ex, ServletWebRequest request) {
+        String message = "Parameter '%s' has invalid value '%s'".formatted(ex.getName(), ex.getValue());
+        return buildResponse(HttpStatus.BAD_REQUEST, "INVALID_PARAMETER", message, request);
     }
 
     @ExceptionHandler(IllegalArgumentException.class)


### PR DESCRIPTION
## Summary
- replace the session rename and favorite endpoints with PATCH handlers and update the API reference
- add size validations to chat rename and message payloads to align with existing DTO constraints
- expand exception handling for malformed requests so INTERNAL_ERROR is only emitted for unexpected failures

## Testing
- mvn test *(fails: unable to download Maven dependencies due to 403 from Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_68de1ef5e6bc8327b5c4160457c7d17e