### PR TITLE
Add request and response logging filter

### DIFF
--- a/src/main/java/com/example/chatstorage/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/chatstorage/error/GlobalExceptionHandler.java
@@ -5,9 +5,9 @@ import com.example.chatstorage.security.exception.ApiKeyRateLimitExceededExcepti
 import com.example.chatstorage.security.exception.InvalidApiKeyException;
 import com.example.chatstorage.security.exception.MissingApiKeyException;
 import com.example.chatstorage.service.ResourceNotFoundException;
+import jakarta.validation.ConstraintViolationException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import jakarta.validation.ConstraintViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
@@ -25,31 +25,31 @@ import java.util.stream.Collectors;
 @ControllerAdvice
 public class GlobalExceptionHandler {
 
-    private static final Logger log = LogManager.getLogger(GlobalExceptionHandler.class);
+    private static final Logger errorLogger = LogManager.getLogger("ERROR_LOG");
 
     @ExceptionHandler(MissingApiKeyException.class)
     public ResponseEntity<ApiError> handleMissingApiKey(MissingApiKeyException ex, ServletWebRequest request) {
-        return buildResponse(HttpStatus.UNAUTHORIZED, "MISSING_API_KEY", ex.getMessage(), request);
+        return buildResponse(HttpStatus.UNAUTHORIZED, "MISSING_API_KEY", ex.getMessage(), request, ex);
     }
 
     @ExceptionHandler(InvalidApiKeyException.class)
     public ResponseEntity<ApiError> handleInvalidApiKey(InvalidApiKeyException ex, ServletWebRequest request) {
-        return buildResponse(HttpStatus.UNAUTHORIZED, "INVALID_API_KEY", ex.getMessage(), request);
+        return buildResponse(HttpStatus.UNAUTHORIZED, "INVALID_API_KEY", ex.getMessage(), request, ex);
     }
 
     @ExceptionHandler(ApiKeyExpiredException.class)
     public ResponseEntity<ApiError> handleExpiredApiKey(ApiKeyExpiredException ex, ServletWebRequest request) {
-        return buildResponse(HttpStatus.UNAUTHORIZED, "API_KEY_EXPIRED", ex.getMessage(), request);
+        return buildResponse(HttpStatus.UNAUTHORIZED, "API_KEY_EXPIRED", ex.getMessage(), request, ex);
     }
 
     @ExceptionHandler(ApiKeyRateLimitExceededException.class)
     public ResponseEntity<ApiError> handleRateLimitExceeded(ApiKeyRateLimitExceededException ex, ServletWebRequest request) {
-        return buildResponse(HttpStatus.TOO_MANY_REQUESTS, "RATE_LIMIT_EXCEEDED", ex.getMessage(), request);
+        return buildResponse(HttpStatus.TOO_MANY_REQUESTS, "RATE_LIMIT_EXCEEDED", ex.getMessage(), request, ex);
     }
 
     @ExceptionHandler(ResourceNotFoundException.class)
     public ResponseEntity<ApiError> handleNotFound(ResourceNotFoundException ex, ServletWebRequest request) {
-        return buildResponse(HttpStatus.NOT_FOUND, "NOT_FOUND", ex.getMessage(), request);
+        return buildResponse(HttpStatus.NOT_FOUND, "NOT_FOUND", ex.getMessage(), request, ex);
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
@@ -57,7 +57,7 @@ public class GlobalExceptionHandler {
         String message = ex.getBindingResult().getFieldErrors().stream()
                 .map(this::formatFieldError)
                 .collect(Collectors.joining(", "));
-        return buildResponse(HttpStatus.BAD_REQUEST, "VALIDATION_ERROR", message, request);
+        return buildResponse(HttpStatus.BAD_REQUEST, "VALIDATION_ERROR", message, request, ex);
     }
 
     @ExceptionHandler(ConstraintViolationException.class)
@@ -65,43 +65,53 @@ public class GlobalExceptionHandler {
         String message = ex.getConstraintViolations().stream()
                 .map(violation -> violation.getPropertyPath() + " " + violation.getMessage())
                 .collect(Collectors.joining(", "));
-        return buildResponse(HttpStatus.BAD_REQUEST, "CONSTRAINT_VIOLATION", message, request);
+        return buildResponse(HttpStatus.BAD_REQUEST, "CONSTRAINT_VIOLATION", message, request, ex);
     }
 
     @ExceptionHandler(HttpMessageNotReadableException.class)
     public ResponseEntity<ApiError> handleMessageNotReadable(HttpMessageNotReadableException ex, ServletWebRequest request) {
-        return buildResponse(HttpStatus.BAD_REQUEST, "INVALID_REQUEST_BODY", "Request body is malformed or missing", request);
+        return buildResponse(HttpStatus.BAD_REQUEST, "INVALID_REQUEST_BODY", "Request body is malformed or missing", request, ex);
     }
 
     @ExceptionHandler(MissingServletRequestParameterException.class)
     public ResponseEntity<ApiError> handleMissingParameter(MissingServletRequestParameterException ex, ServletWebRequest request) {
         String message = "Missing required parameter '%s'".formatted(ex.getParameterName());
-        return buildResponse(HttpStatus.BAD_REQUEST, "MISSING_PARAMETER", message, request);
+        return buildResponse(HttpStatus.BAD_REQUEST, "MISSING_PARAMETER", message, request, ex);
     }
 
     @ExceptionHandler(MethodArgumentTypeMismatchException.class)
     public ResponseEntity<ApiError> handleTypeMismatch(MethodArgumentTypeMismatchException ex, ServletWebRequest request) {
         String message = "Parameter '%s' has invalid value '%s'".formatted(ex.getName(), ex.getValue());
-        return buildResponse(HttpStatus.BAD_REQUEST, "INVALID_PARAMETER", message, request);
+        return buildResponse(HttpStatus.BAD_REQUEST, "INVALID_PARAMETER", message, request, ex);
     }
 
     @ExceptionHandler(IllegalArgumentException.class)
     public ResponseEntity<ApiError> handleIllegalArgument(IllegalArgumentException ex, ServletWebRequest request) {
-        return buildResponse(HttpStatus.BAD_REQUEST, "INVALID_ARGUMENT", ex.getMessage(), request);
+        return buildResponse(HttpStatus.BAD_REQUEST, "INVALID_ARGUMENT", ex.getMessage(), request, ex);
     }
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ApiError> handleGeneric(Exception ex, ServletWebRequest request) {
-        log.error("Unexpected error", ex);
-        return buildResponse(HttpStatus.INTERNAL_SERVER_ERROR, "INTERNAL_ERROR", "An unexpected error occurred", request);
+        return buildResponse(HttpStatus.INTERNAL_SERVER_ERROR, "INTERNAL_ERROR", "An unexpected error occurred", request, ex);
     }
 
-    private ResponseEntity<ApiError> buildResponse(HttpStatus status, String code, String message, ServletWebRequest request) {
+    private ResponseEntity<ApiError> buildResponse(HttpStatus status, String code, String message, ServletWebRequest request, Exception ex) {
         ApiError error = new ApiError(OffsetDateTime.now(), code, message, request.getRequest().getRequestURI());
+        logException(status, code, message, request, ex);
         return ResponseEntity.status(status).body(error);
     }
 
     private String formatFieldError(FieldError error) {
         return "%s %s".formatted(error.getField(), error.getDefaultMessage());
+    }
+
+    private void logException(HttpStatus status, String code, String message, ServletWebRequest request, Exception ex) {
+        String path = request.getRequest().getRequestURI();
+        if (status.is5xxServerError()) {
+            errorLogger.error("status={} code={} path={} message={}", status.value(), code, path, message, ex);
+        } else {
+            errorLogger.warn("status={} code={} path={} message={} exception={}",
+                    status.value(), code, path, message, ex.getMessage());
+        }
     }
 }

--- a/src/main/java/com/example/chatstorage/logging/RequestResponseLoggingFilter.java
+++ b/src/main/java/com/example/chatstorage/logging/RequestResponseLoggingFilter.java
@@ -1,0 +1,93 @@
+package com.example.chatstorage.logging;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+import org.springframework.web.util.ContentCachingRequestWrapper;
+import org.springframework.web.util.ContentCachingResponseWrapper;
+
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Component
+public class RequestResponseLoggingFilter extends OncePerRequestFilter {
+
+    private static final Logger requestLogger = LogManager.getLogger("REQUEST_LOG");
+    private static final Logger responseLogger = LogManager.getLogger("RESPONSE_LOG");
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+        ContentCachingRequestWrapper requestWrapper = wrapRequest(request);
+        ContentCachingResponseWrapper responseWrapper = wrapResponse(response);
+        long startTime = System.currentTimeMillis();
+        try {
+            filterChain.doFilter(requestWrapper, responseWrapper);
+        } finally {
+            long duration = System.currentTimeMillis() - startTime;
+            logRequest(requestWrapper);
+            logResponse(responseWrapper, duration);
+            responseWrapper.copyBodyToResponse();
+        }
+    }
+
+    private ContentCachingRequestWrapper wrapRequest(HttpServletRequest request) {
+        if (request instanceof ContentCachingRequestWrapper wrapper) {
+            return wrapper;
+        }
+        return new ContentCachingRequestWrapper(request);
+    }
+
+    private ContentCachingResponseWrapper wrapResponse(HttpServletResponse response) {
+        if (response instanceof ContentCachingResponseWrapper wrapper) {
+            return wrapper;
+        }
+        return new ContentCachingResponseWrapper(response);
+    }
+
+    private void logRequest(ContentCachingRequestWrapper request) {
+        Map<String, String> headers = Collections.list(request.getHeaderNames()).stream()
+                .collect(Collectors.toMap(name -> name, request::getHeader, (first, second) -> second, LinkedHashMap::new));
+
+        String payload = getPayload(request.getContentAsByteArray(), request.getCharacterEncoding());
+        String queryString = request.getQueryString();
+
+        requestLogger.info("method={} uri={} query={} headers={} payload={}",
+                request.getMethod(),
+                request.getRequestURI(),
+                queryString != null ? queryString : "",
+                headers,
+                payload);
+    }
+
+    private void logResponse(ContentCachingResponseWrapper response, long duration) {
+        Map<String, String> headers = response.getHeaderNames().stream()
+                .collect(Collectors.toMap(name -> name, response::getHeader, (first, second) -> second, LinkedHashMap::new));
+
+        String payload = getPayload(response.getContentAsByteArray(), response.getCharacterEncoding());
+
+        responseLogger.info("status={} durationMs={} headers={} payload={}",
+                response.getStatus(),
+                duration,
+                headers,
+                payload);
+    }
+
+    private String getPayload(byte[] content, String charsetName) {
+        if (content == null || content.length == 0) {
+            return "";
+        }
+        Charset charset = charsetName != null ? Charset.forName(charsetName) : StandardCharsets.UTF_8;
+        return new String(content, charset);
+    }
+}

--- a/src/main/resources/log4j2-spring.xml
+++ b/src/main/resources/log4j2-spring.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="WARN">
+    <Appenders>
+        <Console name="Console" target="SYSTEM_OUT">
+            <PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss.SSS} %-5level [%t] %c{1} - %msg%n"/>
+        </Console>
+
+        <RollingFile name="RequestFile"
+                     fileName="logs/request.log"
+                     filePattern="logs/request-%d{yyyy-MM-dd}-%i.log.gz">
+            <PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss.SSS} %-5level %msg%n"/>
+            <Policies>
+                <TimeBasedTriggeringPolicy/>
+                <SizeBasedTriggeringPolicy size="10 MB"/>
+            </Policies>
+        </RollingFile>
+
+        <RollingFile name="ResponseFile"
+                     fileName="logs/response.log"
+                     filePattern="logs/response-%d{yyyy-MM-dd}-%i.log.gz">
+            <PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss.SSS} %-5level %msg%n"/>
+            <Policies>
+                <TimeBasedTriggeringPolicy/>
+                <SizeBasedTriggeringPolicy size="10 MB"/>
+            </Policies>
+        </RollingFile>
+
+        <RollingFile name="ErrorFile"
+                     fileName="logs/error.log"
+                     filePattern="logs/error-%d{yyyy-MM-dd}-%i.log.gz">
+            <PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss.SSS} %-5level %msg%n%throwable"/>
+            <Policies>
+                <TimeBasedTriggeringPolicy/>
+                <SizeBasedTriggeringPolicy size="10 MB"/>
+            </Policies>
+        </RollingFile>
+    </Appenders>
+
+    <Loggers>
+        <Logger name="REQUEST_LOG" level="info" additivity="false">
+            <AppenderRef ref="RequestFile"/>
+        </Logger>
+
+        <Logger name="RESPONSE_LOG" level="info" additivity="false">
+            <AppenderRef ref="ResponseFile"/>
+        </Logger>
+
+        <Logger name="ERROR_LOG" level="info" additivity="false">
+            <AppenderRef ref="ErrorFile"/>
+        </Logger>
+
+        <Root level="info">
+            <AppenderRef ref="Console"/>
+        </Root>
+    </Loggers>
+</Configuration>


### PR DESCRIPTION
## Summary
- add a Log4j2 configuration that writes request, response, and error logs to dedicated rolling files
- introduce a OncePerRequestFilter that captures request and response metadata and bodies for every interaction
- enhance the global exception handler to log all handled exceptions through the centralized error logger

## Testing
- `mvn -q -DskipTests=false test` *(fails: unable to download dependencies from Maven Central due to HTTP 403 in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e54ffc0700832794ef8e50aa407fa2